### PR TITLE
Support DI with array of descendants

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,50 @@ Syringe.wrap(Q)
 q = Q.new # t.i_num will be 1
 q = Q.new # t.i_num will be 2
 ```
+If you want to have an array within the constructor.
+```
+module Animal
+  abstract def say(sentence : string)
+end
+
+class Animals
+  include Syringe
+  def initialize(@animals : Array(Animal)
+  end
+
+  def say(sentence : string)
+    @animals.each do |animal|
+      animal.say(sentence)
+    end
+  end
+end
+
+class Dog
+  Syringe.injectable
+  include Animal
+
+  def say(sentence : string)
+    puts "Woof! #{sentence}"
+  end
+end
+
+class Cat
+  Syringe.injectable
+  include Animal
+
+  def say(sentence : string)
+    puts "Meow! #{sentence}"
+  end
+end
+
+animals = Animals.new
+animals.say("Hi")
+```
+This would output
+```
+Woof! Hi
+Meow! Hi
+```
 
 ## Development
 

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -67,3 +67,30 @@ class TRegistered
 end
 Syringe.wrap(TRegistered)
 
+module Item
+end
+
+class Items
+  include Syringe
+  def initialize(@items : Array(Item))
+  end
+
+  def count
+    @items.size
+  end
+end
+
+class Item1
+  include Item
+  Syringe.injectable
+end
+
+class Item2
+  include Item
+  Syringe.injectable
+end
+
+class Item3
+  include Item
+  Syringe.injectable
+end

--- a/spec/syringe_spec.cr
+++ b/spec/syringe_spec.cr
@@ -74,4 +74,9 @@ describe Syringe do
     t = SingletonProvidedInstance.new
     t.i.get_counter.should eq(2)
   end
+
+  it "should allow arguments as array of classes that have mixin" do
+    items = Items.new
+    items.count.should eq(3)
+  end
 end


### PR DESCRIPTION
Goal: Support Dependency Injections when the argument is an array. The type of the array is used to find all the descendants of that type.