### PR TITLE
Add convenience macros for defining providers

### DIFF
--- a/spec/syringe_spec.cr
+++ b/spec/syringe_spec.cr
@@ -34,6 +34,16 @@ class SingletonProvidedInstance
 end
 Syringe.wrap(SingletonProvidedInstance)
 
+module ThemClasses
+  class JustAnInjectable
+  end
+
+  class AnInjectableWrap
+    def initialize(@i : JustAnInjectable)
+    end
+  end
+end
+
 describe Syringe do
   it "should be able to inject when included" do
     t = TInclude.new
@@ -78,5 +88,24 @@ describe Syringe do
   it "should allow arguments as array of classes that have mixin" do
     items = Items.new
     items.count.should eq(3)
+  end
+
+  it "should inject and wrap where able to" do
+    Syringe.define_providers(
+      ThemClasses::JustAnInjectable,
+      ThemClasses::AnInjectableWrap
+    )
+
+    t = AnInjectableWrap.new
+    t.i.should be_a(ThemClasses::JustAnInjectable)
+  end
+
+  it "should inject as a Singleton and wrap where able to" do
+    Syringe.injectable(ThemClasses::JustAnInjectable)
+    Syringe.define_singleton_providers(ThemClasses::AnInjectableWrap)
+
+    t = AnInjectableWrap.new
+    r = AnInjectableWrap.new
+    t.should eq(r)
   end
 end

--- a/src/syringe.cr
+++ b/src/syringe.cr
@@ -49,5 +49,47 @@ module Syringe
 				end
 			{% end %}
 		end
-	end
+  end
+
+  macro auto_wrap(klass)
+    \{% if !{{klass}}.methods.select { |m| m.name == "initialize" }.empty? %}
+      \{% if !{{klass}}.methods.select { |m| m.name == "initialize" }[0].args.empty? %}
+        Syringe.wrap({{klass}})
+      \{% end %}
+    \{% end %}
+  end
+
+  macro define_providers(*klasses)
+    {% for klass in klasses  %}
+      module {{ klass.id.split("::").reject { |k| k == klass.id.split("::").last}.join("::").id }}
+        class {{ klass }}Provider
+          Syringe.provide({{klass}})
+
+          def self.getInstance
+            {{klass}}.new
+          end
+        end
+      end
+
+      Syringe.auto_wrap({{klass}})
+    {% end %}
+  end
+
+  macro define_singleton_providers(*klasses)
+    {% for klass in klasses  %}
+      module {{ klass.id.split("::").reject { |k| k == klass.id.split("::").last}.join("::").id }}
+        class {{ klass }}Provider
+          Syringe.provide({{klass}})
+
+          @@instance = {{klass}}.new
+
+          def self.getInstance
+            @@instance
+          end
+        end
+      end
+
+      Syringe.auto_wrap({{klass}})
+    {% end %}
+  end
 end


### PR DESCRIPTION
#### Context

Perhaps useful, this PR aims to add `define_singleton_providers` and `define_providers` macros to add both `injectable` and `wrap` (where applicable) functionality to classes, while honouring namespaces.

#### Considerations

Depends on the work over at https://github.com/Bonemind/syringe/pull/3